### PR TITLE
Updating to remove dependencies on Charts and vtkMRMLDoubleArrayNode

### DIFF
--- a/WorkflowSegmentation/Logic/vtkSlicerWorkflowSegmentationLogic.cxx
+++ b/WorkflowSegmentation/Logic/vtkSlicerWorkflowSegmentationLogic.cxx
@@ -114,6 +114,10 @@ void vtkSlicerWorkflowSegmentationLogic
   vtkMRMLWorkflowToolNode* toolNode = vtkMRMLWorkflowToolNode::New();
   this->GetMRMLScene()->RegisterNodeClass( toolNode );
   toolNode->Delete();
+
+  vtkMRMLWorkflowDoubleArrayNode* arrayNode = vtkMRMLWorkflowDoubleArrayNode::New();
+  this->GetMRMLScene()->RegisterNodeClass(arrayNode);
+  arrayNode->Delete();
 }
 
 

--- a/WorkflowSegmentation/MRML/CMakeLists.txt
+++ b/WorkflowSegmentation/MRML/CMakeLists.txt
@@ -20,6 +20,9 @@ set(${KIT}_SRCS
   vtkMarkovModelOnline.cxx
   vtkMarkovModelOnline.h
   
+  vtkMRMLWorkflowDoubleArrayNode.cxx
+  vtkMRMLWorkflowDoubleArrayNode.h
+  
   vtkMRMLWorkflowSequenceNode.cxx
   vtkMRMLWorkflowSequenceNode.h
   vtkMRMLWorkflowSequenceOnlineNode.cxx

--- a/WorkflowSegmentation/MRML/vtkMRMLWorkflowDoubleArrayNode.cxx
+++ b/WorkflowSegmentation/MRML/vtkMRMLWorkflowDoubleArrayNode.cxx
@@ -1,0 +1,72 @@
+
+#include "vtkMRMLWorkflowDoubleArrayNode.h"
+
+// Standard MRML Node Methods ------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+vtkCxxSetObjectMacro(vtkMRMLWorkflowDoubleArrayNode, Array, vtkDoubleArray)
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLWorkflowDoubleArrayNode);
+
+
+
+void vtkMRMLWorkflowDoubleArrayNode
+::CopyContent( vtkMRMLNode *anode, bool deepCopy/*=true*/ )
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+
+  vtkMRMLWorkflowDoubleArrayNode* sourceDoubleArrayNode = vtkMRMLWorkflowDoubleArrayNode::SafeDownCast(anode);
+  if (sourceDoubleArrayNode == NULL)
+  {
+    return;
+  }
+  if (deepCopy)
+  {
+    if (sourceDoubleArrayNode->GetArray() != NULL)
+    {
+      if (this->GetArray() != NULL)
+      {
+        this->GetArray()->DeepCopy(sourceDoubleArrayNode->GetArray());
+      }
+      else
+      {
+        vtkSmartPointer<vtkDoubleArray> newArray = vtkSmartPointer<vtkDoubleArray>::Take(sourceDoubleArrayNode->GetArray()->NewInstance());
+        newArray->DeepCopy(sourceDoubleArrayNode->GetArray());
+        this->SetArray(newArray);
+      }
+    }
+    else
+    {
+      // input was nullptr
+      this->SetArray(nullptr);
+    }
+  }
+  else
+  {
+    // shallow-copy
+    this->SetArray(sourceDoubleArrayNode->GetArray());
+  }
+}
+
+
+
+// Constructors and Destructors --------------------------------------------------------------------
+
+vtkMRMLWorkflowDoubleArrayNode
+::vtkMRMLWorkflowDoubleArrayNode()
+{
+  this->Array = vtkDoubleArray::New();
+}
+
+
+vtkMRMLWorkflowDoubleArrayNode
+::~vtkMRMLWorkflowDoubleArrayNode()
+{
+  if (this->Array)
+  {
+	this->Array->Delete();
+	this->Array = nullptr;
+  }
+}

--- a/WorkflowSegmentation/MRML/vtkMRMLWorkflowDoubleArrayNode.h
+++ b/WorkflowSegmentation/MRML/vtkMRMLWorkflowDoubleArrayNode.h
@@ -1,0 +1,53 @@
+
+#ifndef __vtkMRMLWorkflowDoubleArrayNode_h
+#define __vtkMRMLWorkflowDoubleArrayNode_h
+
+// Standard Includes
+#include <string>
+#include <sstream>
+#include <vector>
+#include <cmath>
+
+// VTK includes
+#include "vtkObject.h"
+#include "vtkObjectBase.h"
+#include "vtkObjectFactory.h"
+#include "vtkDoubleArray.h"
+
+#include "vtkMRMLNode.h"
+
+// Workflow Segmentation includes
+#include "vtkSlicerWorkflowSegmentationModuleMRMLExport.h"
+
+// This class stores a vector of values and a string label
+class VTK_SLICER_WORKFLOWSEGMENTATION_MODULE_MRML_EXPORT 
+vtkMRMLWorkflowDoubleArrayNode : public vtkMRMLNode
+{
+public:
+  vtkTypeMacro( vtkMRMLWorkflowDoubleArrayNode, vtkMRMLNode );
+
+  // Standard MRML node methods  
+  static vtkMRMLWorkflowDoubleArrayNode* New();
+  vtkMRMLNode* CreateNodeInstance() override;
+  virtual const char* GetNodeTagName() override { return "WorkflowDoubleArray"; };
+
+  vtkMRMLCopyContentMacro(vtkMRMLWorkflowDoubleArrayNode);
+  
+protected:
+
+  // Constructor/desctructor
+  vtkMRMLWorkflowDoubleArrayNode();
+  virtual ~vtkMRMLWorkflowDoubleArrayNode();
+  vtkMRMLWorkflowDoubleArrayNode ( const vtkMRMLWorkflowDoubleArrayNode& ); // Required to prevent linking error
+  void operator=( const vtkMRMLWorkflowDoubleArrayNode& ); // Required to prevent linking error
+
+public:
+  // Getters/setters for properties
+  virtual void SetArray(vtkDoubleArray*);
+  vtkGetObjectMacro(Array, vtkDoubleArray);
+  
+protected:
+  vtkDoubleArray* Array;	// The array
+};
+
+#endif

--- a/WorkflowSegmentation/MRML/vtkMRMLWorkflowSequenceNode.cxx
+++ b/WorkflowSegmentation/MRML/vtkMRMLWorkflowSequenceNode.cxx
@@ -133,7 +133,7 @@ int vtkMRMLWorkflowSequenceNode
 vtkDoubleArray* vtkMRMLWorkflowSequenceNode
 ::GetNthDoubleArray( int itemNumber )
 {
-  vtkMRMLDoubleArrayNode* doubleArrayNode = vtkMRMLDoubleArrayNode::SafeDownCast( this->GetNthDataNode( itemNumber ) );
+  vtkMRMLWorkflowDoubleArrayNode* doubleArrayNode = vtkMRMLWorkflowDoubleArrayNode::SafeDownCast( this->GetNthDataNode( itemNumber ) );
   if ( doubleArrayNode == NULL )
   {
     return NULL;
@@ -178,7 +178,7 @@ void vtkMRMLWorkflowSequenceNode
   }
 
   // Add the transform nodes to this workflow sequence as double array nodes
-  vtkSmartPointer< vtkMRMLDoubleArrayNode > doubleArrayNode = vtkSmartPointer< vtkMRMLDoubleArrayNode >::New();
+  vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode > doubleArrayNode = vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode >::New();
   for ( int i = 0; i < sequenceNode->GetNumberOfDataNodes(); i++ )
   {    
     this->LinearTransformToDoubleArray( vtkMRMLLinearTransformNode::SafeDownCast( sequenceNode->GetNthDataNode( i ) ), doubleArrayNode, QUATERNION_ARRAY ); // Use quaternions
@@ -691,7 +691,7 @@ void vtkMRMLWorkflowSequenceNode
         tempUnintegratedDoubleArray->SetComponent( 0, d, currentDoubleArray->GetComponent( 0, d ) * legendrePolynomial );
 	    }
 
-      vtkSmartPointer< vtkMRMLDoubleArrayNode > unintegratedDataNode = vtkSmartPointer< vtkMRMLDoubleArrayNode >::New();
+      vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode > unintegratedDataNode = vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode >::New();
       vtkDoubleArray* unintegratedDoubleArray = unintegratedDataNode->GetArray();
       if ( unintegratedDoubleArray == NULL )
       {
@@ -1298,7 +1298,7 @@ void vtkMRMLWorkflowSequenceNode
     }
     currDataNode->SetAttribute( "MarkovState", currDataNode->GetAttribute( "Message" ) );
 
-    vtkMRMLDoubleArrayNode* currDoubleArrayNode = vtkMRMLDoubleArrayNode::SafeDownCast( currDataNode );
+    vtkMRMLWorkflowDoubleArrayNode* currDoubleArrayNode = vtkMRMLWorkflowDoubleArrayNode::SafeDownCast( currDataNode );
     if ( currDoubleArrayNode == NULL || currDoubleArrayNode->GetArray() == NULL )
     {
       return;
@@ -1311,7 +1311,7 @@ void vtkMRMLWorkflowSequenceNode
 
 
 void vtkMRMLWorkflowSequenceNode
-::LinearTransformFromDoubleArray( vtkMRMLLinearTransformNode* transformNode, vtkMRMLDoubleArrayNode* doubleArrayNode, ArrayType type )
+::LinearTransformFromDoubleArray( vtkMRMLLinearTransformNode* transformNode, vtkMRMLWorkflowDoubleArrayNode* doubleArrayNode, ArrayType type )
 {
   vtkDoubleArray* doubleArray = doubleArrayNode->GetArray();
   if ( doubleArray == NULL || doubleArray->GetNumberOfTuples() != 1 )
@@ -1370,7 +1370,7 @@ void vtkMRMLWorkflowSequenceNode
 
 
 void vtkMRMLWorkflowSequenceNode
-::LinearTransformToDoubleArray( vtkMRMLLinearTransformNode* transformNode, vtkMRMLDoubleArrayNode* doubleArrayNode, ArrayType type )
+::LinearTransformToDoubleArray( vtkMRMLLinearTransformNode* transformNode, vtkMRMLWorkflowDoubleArrayNode* doubleArrayNode, ArrayType type )
 {
   vtkDoubleArray* doubleArray = doubleArrayNode->GetArray();
 

--- a/WorkflowSegmentation/MRML/vtkMRMLWorkflowSequenceNode.h
+++ b/WorkflowSegmentation/MRML/vtkMRMLWorkflowSequenceNode.h
@@ -29,12 +29,12 @@
 
 #include "vtkMRMLSequenceNode.h"
 #include "vtkMRMLSequenceBrowserNode.h"
-#include "vtkMRMLDoubleArrayNode.h"
+#include "vtkMRMLWorkflowDoubleArrayNode.h"
 #include "vtkMRMLLinearTransformNode.h"
 #include "vtkMRMLScene.h"
 
 
-// This is a sequence node which only takes vtkMRMLDoubleArrayNodes
+// This is a sequence node which only takes vtkMRMLWorkflowDoubleArrayNodes
 // But it allows us to do special computations on these nodes
 class VTK_SLICER_WORKFLOWSEGMENTATION_MODULE_MRML_EXPORT
 vtkMRMLWorkflowSequenceNode : public vtkMRMLSequenceNode
@@ -112,8 +112,8 @@ public:
   };
     
   // Convert between linear transforms and double arrays
-  static void LinearTransformFromDoubleArray( vtkMRMLLinearTransformNode* transformNode, vtkMRMLDoubleArrayNode* doubleArrayNode, ArrayType type );
-  static void LinearTransformToDoubleArray( vtkMRMLLinearTransformNode* transformNode, vtkMRMLDoubleArrayNode* doubleArrayNode, ArrayType type );
+  static void LinearTransformFromDoubleArray( vtkMRMLLinearTransformNode* transformNode, vtkMRMLWorkflowDoubleArrayNode* doubleArrayNode, ArrayType type );
+  static void LinearTransformToDoubleArray( vtkMRMLLinearTransformNode* transformNode, vtkMRMLWorkflowDoubleArrayNode* doubleArrayNode, ArrayType type );
 
   // Helper method (since this isn't implemented in the version of VTK that Slicer uses)
   static void FillDoubleArray( vtkDoubleArray* doubleArray, double fillValue );

--- a/WorkflowSegmentation/MRML/vtkMRMLWorkflowSequenceOnlineNode.cxx
+++ b/WorkflowSegmentation/MRML/vtkMRMLWorkflowSequenceOnlineNode.cxx
@@ -312,7 +312,7 @@ void vtkMRMLWorkflowSequenceOnlineNode
   // We will assume that: label -> state, values[0] -> symbol
   node->SetAttribute( "MarkovState", node->GetAttribute( "Message" ) );
   
-  vtkMRMLDoubleArrayNode* doubleArrayNode = vtkMRMLDoubleArrayNode::SafeDownCast( node );
+  vtkMRMLWorkflowDoubleArrayNode* doubleArrayNode = vtkMRMLWorkflowDoubleArrayNode::SafeDownCast( node );
   if ( doubleArrayNode == NULL || doubleArrayNode->GetArray() == NULL )
   {
     return;

--- a/WorkflowSegmentation/MRML/vtkMRMLWorkflowToolNode.cxx
+++ b/WorkflowSegmentation/MRML/vtkMRMLWorkflowToolNode.cxx
@@ -499,12 +499,12 @@ bool vtkMRMLWorkflowToolNode
 void vtkMRMLWorkflowToolNode
 ::AddAndSegmentTransform( vtkMRMLLinearTransformNode* newTransformNode, std::string newTimeString )
 {
-  vtkSmartPointer< vtkMRMLDoubleArrayNode > rawDoubleArrayNode = vtkSmartPointer< vtkMRMLDoubleArrayNode >::New();
+  vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode > rawDoubleArrayNode = vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode >::New();
   vtkMRMLWorkflowSequenceNode::LinearTransformToDoubleArray( newTransformNode, rawDoubleArrayNode, vtkMRMLWorkflowSequenceNode::QUATERNION_ARRAY );
   this->RawWorkflowSequence->SetDataNodeAtValue( rawDoubleArrayNode, newTimeString );
 
   // Apply Gaussian filtering to each previous records
-  vtkSmartPointer< vtkMRMLDoubleArrayNode > gaussDoubleArrayNode = vtkSmartPointer< vtkMRMLDoubleArrayNode >::New();
+  vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode > gaussDoubleArrayNode = vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode >::New();
   this->RawWorkflowSequence->GaussianFilterOnline( this->GetWorkflowInputNode()->GetFilterWidth(), gaussDoubleArrayNode->GetArray() );
   this->FilterWorkflowSequence->SetDataNodeAtValue( gaussDoubleArrayNode, newTimeString );
   
@@ -522,22 +522,22 @@ void vtkMRMLWorkflowToolNode
 
     vtkMRMLWorkflowSequenceNode::ConcatenateDoubleArrays( tempDerivativeDoubleArray, currDerivativeDoubleArray, derivativeDoubleArray.GetPointer() );
   }
-  vtkSmartPointer< vtkMRMLDoubleArrayNode > derivativeDoubleArrayNode = vtkSmartPointer< vtkMRMLDoubleArrayNode >::New();
+  vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode > derivativeDoubleArrayNode = vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode >::New();
   derivativeDoubleArrayNode->GetArray()->DeepCopy( derivativeDoubleArray.GetPointer() );
   this->DerivativeWorkflowSequence->SetDataNodeAtValue( derivativeDoubleArrayNode, newTimeString );
 
   // Apply orthogonal transformation
-  vtkSmartPointer< vtkMRMLDoubleArrayNode > orthogonalDoubleArrayNode = vtkSmartPointer< vtkMRMLDoubleArrayNode >::New();
+  vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode > orthogonalDoubleArrayNode = vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode >::New();
   this->DerivativeWorkflowSequence->OrthogonalTransformationOnline( this->GetWorkflowInputNode()->GetOrthogonalWindow(), this->GetWorkflowInputNode()->GetOrthogonalOrder(), orthogonalDoubleArrayNode->GetArray() );
   this->OrthogonalWorkflowSequence->SetDataNodeAtValue( orthogonalDoubleArrayNode, newTimeString );
 
   // Apply PCA transformation
-  vtkSmartPointer< vtkMRMLDoubleArrayNode > pcaDoubleArrayNode = vtkSmartPointer< vtkMRMLDoubleArrayNode >::New();
+  vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode > pcaDoubleArrayNode = vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode >::New();
   this->OrthogonalWorkflowSequence->TransformByPrincipalComponentsOnline( this->GetWorkflowTrainingNode()->GetPrinComps(), this->GetWorkflowTrainingNode()->GetMean(), pcaDoubleArrayNode->GetArray() );
   this->PcaWorkflowSequence->SetDataNodeAtValue( pcaDoubleArrayNode, newTimeString );
 
   // Apply centroid transformation
-  vtkSmartPointer< vtkMRMLDoubleArrayNode > fwdkmeansDoubleArrayNode = vtkSmartPointer< vtkMRMLDoubleArrayNode >::New();
+  vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode > fwdkmeansDoubleArrayNode = vtkSmartPointer< vtkMRMLWorkflowDoubleArrayNode >::New();
   this->PcaWorkflowSequence->fwdkmeansTransformOnline( this->GetWorkflowTrainingNode()->GetCentroids(), fwdkmeansDoubleArrayNode->GetArray() );
   this->CentroidWorkflowSequence->SetDataNodeAtValue( fwdkmeansDoubleArrayNode, newTimeString );
 
@@ -600,7 +600,7 @@ std::map< std::string, double > vtkMRMLWorkflowToolNode
     
     for ( int j = 0; j < currWorkflowSequence->GetNumberOfDataNodes(); j++ )
 	  {
-      vtkMRMLDoubleArrayNode* currDoubleArrayNode = vtkMRMLDoubleArrayNode::SafeDownCast( currWorkflowSequence->GetNthDataNode( j ) );
+      vtkMRMLWorkflowDoubleArrayNode* currDoubleArrayNode = vtkMRMLWorkflowDoubleArrayNode::SafeDownCast( currWorkflowSequence->GetNthDataNode( j ) );
       if ( currDoubleArrayNode == NULL )
       {
         continue;


### PR DESCRIPTION
Updating plotting of membership functions for fuzzy skill assessment to use the new Plots module.

Added temporary fix to remove dependency on vtkMRMLDoubleArrayNode for workflow segmentation. The update effectively creates a simplified class so that we can continue to work on Sequences of vtkDoubleArrays. The long-term plan is to replace the current method for workflow segmentation with a more modern alternative.