### PR TITLE
STYLE: Upgrade python syntax to 3.9 and newer

### DIFF
--- a/PerkTutorCouchDB/PerkTutorCouchDB.py
+++ b/PerkTutorCouchDB/PerkTutorCouchDB.py
@@ -530,7 +530,7 @@ class PerkTutorCouchDBLogic(ScriptedLoadableModuleLogic):
     fileWriterFileType = ioManager.fileWriterFileType( node )
     fileWriterDefaultExtension = ioManager.fileWriterExtensions( node )[ 0 ]
 
-    extensionRegex = "\.\\w+\\b" # Search for everything after the first . until the next non-alphanumeric character
+    extensionRegex = "\\.\\w+\\b" # Search for everything after the first . until the next non-alphanumeric character
     extensionSpan = re.search( extensionRegex, fileWriterDefaultExtension ).span()
     extension = fileWriterDefaultExtension[ extensionSpan[ 0 ]:extensionSpan[ 1 ] ]
 

--- a/PythonMetricsCalculator/PythonMetricsCalculator.py
+++ b/PythonMetricsCalculator/PythonMetricsCalculator.py
@@ -534,7 +534,7 @@ class PythonMetricsCalculatorLogic( ScriptedLoadableModuleLogic ):
       if ( peNode.GetComputeTaskSpecificMetrics() ):
         if ( trLogic is not None ):
           messageString = trLogic.GetPriorMessageString( peNode.GetTrackedSequenceBrowserNode(), str( time ) )
-          if ( messageString is not "" ):
+          if ( messageString != "" ):
             PythonMetricsCalculatorLogic.UpdateProxyNodeMetrics( allMetrics[ messageString ], proxyNodes, time )
         else:
           logging.warning( "PythonMetricsCalculatorLogic::CalculateAllMetrics: Cannot determine task at index value " + str( time ) + "." )

--- a/PythonMetricsCalculator/PythonMetricsCalculator.py
+++ b/PythonMetricsCalculator/PythonMetricsCalculator.py
@@ -700,7 +700,7 @@ class PythonMetricsCalculatorTest( ScriptedLoadableModuleTest ):
     trueTableID = "vtkMRMLTableNode1"
     
     # Load the scene
-    sceneFile = os.path.join( os.path.dirname( os.path.abspath( __file__ ) ), "Data", "Lumbar", "Scene_Lumbar.mrml" )
+    sceneFile = os.path.join( os.path.dirname(  __file__  ), "Data", "Lumbar", "Scene_Lumbar.mrml" )
     activeScene = slicer.mrmlScene
     activeScene.Clear( 0 )
     activeScene.SetURL( sceneFile )
@@ -709,7 +709,7 @@ class PythonMetricsCalculatorTest( ScriptedLoadableModuleTest ):
 
       
     # Manually load the sequence browser node from the transform buffer xml file
-    transformBufferFile = os.path.join( os.path.dirname( os.path.abspath( __file__ ) ), "Data", "Lumbar", "TransformBuffer_Lumbar_Anonymous.xml" )
+    transformBufferFile = os.path.join( os.path.dirname(  __file__  ), "Data", "Lumbar", "TransformBuffer_Lumbar_Anonymous.xml" )
     success, trackedSequenceBrowserNode = slicer.util.loadNodeFromFile( transformBufferFile, "Tracked Sequence Browser", {}, True ) # This will load into activeScene, since activeScene == slicer.mrmlScene
     if ( not success or trackedSequenceBrowserNode is None ):
       raise Exception( "Could not load tracked sequence browser from: " + transformBufferFile )
@@ -786,7 +786,7 @@ class PythonMetricsCalculatorTest( ScriptedLoadableModuleTest ):
     
     
     # Load the scene
-    sceneFile = os.path.join( os.path.dirname( os.path.abspath( __file__ ) ), "Data", "InPlane", "Scene_InPlane.mrml" )
+    sceneFile = os.path.join( os.path.dirname(  __file__  ), "Data", "InPlane", "Scene_InPlane.mrml" )
     activeScene = slicer.mrmlScene
     activeScene.Clear( 0 )
     activeScene.SetURL( sceneFile )


### PR DESCRIPTION
Some syntax upgrading is necessary for PerkTutor as I noticed in https://slicer.cdash.org/viewBuildError.php?buildid=2581649 that there were syntax warnings. These warnings are present because Slicer recently upgrade from Python 3.6.7 to Python 3.9.10 in https://github.com/Slicer/Slicer/commit/34e48e8aef5dad19ec8a955d6f48a1940846e3f3.

The syntax warning in question started as of Python 3.8.
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

> The compiler now produces a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in [bpo-34850](https://bugs.python.org/issue34850).)

This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. The script listed below was run for Python 3.6+ syntax with changes committed, followed by Python 3.7+, then Python 3.8+ and finally Python 3.9+.  There were no changes made when specifying Python 3.7+ or 3.8+ which is why there are no commits for those iterations.

## Using pyupgrade

- Install: `PythonSlicer -m pip install pyupgrade`
- Running:
  - On 1 file: `PythonSlicer -m pyupgrade --py36-plus MyPythonFile.py`
  - On multiple files: Here is my pyupgrade-script.py written to automate running pyupgrade across all python files in the Slicer repo. It was run by `PythonSlicer pyupgrade-script.py`.
```python
# pyupgrade-script.py
import os
import subprocess

search_directory = "C:/Users/JamesButler/Documents/GitHub/PerkTutor"
for root, _, files in os.walk(search_directory):
    for file_item in files:
        file_path = os.path.join(root, file_item)
        if os.path.isfile(file_path) and file_path.endswith(".py"):
            subprocess.call(["PythonSlicer", "-m", "pyupgrade", "--py36-plus", file_path])
```