### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,12 @@ project( PerkTutor )
 
 # Extension meta-information
 set( EXTENSION_NAME "PerkTutor" )
-set( EXTENSION_HOMEPAGE "https://github.com/PerkTutor/PerkTutor/wiki" )
+set( EXTENSION_HOMEPAGE "https://www.perktutor.org/" )
 set( EXTENSION_CATEGORY "Training" )
 set( EXTENSION_CONTRIBUTORS "Tamas Ungi, Matthew S. Holden (Queen's University)" )
 set( EXTENSION_DESCRIPTION "This extension holds modules for training of needle interventions and analysis of operator performance." )
-set( EXTENSION_ICONURL "http://www.slicer.org/slicerWiki/images/2/21/PerkTutorLogo.png" )
-set( EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/2/28/PerkTutorScreenshot.png" )
+set( EXTENSION_ICONURL "https://www.slicer.org/slicerWiki/images/2/21/PerkTutorLogo.png" )
+set( EXTENSION_SCREENSHOTURLS "https://www.slicer.org/slicerWiki/images/2/28/PerkTutorScreenshot.png" )
 set( EXTENSION_DEPENDS "NA" ) # Specified as a space separated list or 'NA' if any
 
 


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.